### PR TITLE
Prevent infinite loop when disposing the EffectComposer

### DIFF
--- a/dist/ScreenSpaceReflections.js
+++ b/dist/ScreenSpaceReflections.js
@@ -276,7 +276,6 @@ class ReflectionsPass extends Pass {
       value: false
     });
 
-    this.composer = composer;
     this._scene = scene;
     this._camera = camera;
 
@@ -445,7 +444,6 @@ const defaultOptions = {
 class SSRPass extends Pass {
   constructor(composer, scene, camera, options = defaultOptions) {
     super("SSRPass");
-    this.composer = composer;
     this._camera = camera;
     options = _objectSpread(_objectSpread({}, defaultOptions), options);
     this.fullscreenMaterial = new SSRCompositeMaterial(); // returns just the calculates reflections

--- a/src/ssr/ReflectionsPass.js
+++ b/src/ssr/ReflectionsPass.js
@@ -19,7 +19,6 @@ export class ReflectionsPass extends Pass {
 	constructor(composer, scene, camera, options = {}) {
 		super("ReflectionsPass")
 
-		this.composer = composer
 		this._scene = scene
 		this._camera = camera
 		this.#options = options

--- a/src/ssr/SSRPass.js
+++ b/src/ssr/SSRPass.js
@@ -34,7 +34,6 @@ export class SSRPass extends Pass {
 	constructor(composer, scene, camera, options = defaultOptions) {
 		super("SSRPass")
 
-		this.composer = composer
 		this._camera = camera
 		options = { ...defaultOptions, ...options }
 


### PR DESCRIPTION
IMHO the real problem is not here, it's there instead : https://github.com/pmndrs/postprocessing/blob/877cda9c93aa3ed6106062e0010674c1641a56a7/src/passes/Pass.js#L371-L388

It blindly calls the dispose method on all props of a Pass, which leads to unpredictable side effects like what I experienced...
Basically, when an EffectComposer is disposed, it will dispose it's passes, but the SSRPass will call the dispose method of it's composer prop, which will dispose it's passes again, ...infinite loop ♾️

So I removed those props in your passes to avoid the problem. 🤷🏼‍♂️  (they were not used anyway)

btw thanks for this project, it looks promising ! 🙂 